### PR TITLE
Add a start flag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,4 @@ default["dnsmasq"]["conf_dir"] = "/etc/dnsmasq.d"
 
 default["dnsmasq"]["tftp_root"] = "/var/ftpd"
 default["dnsmasq"]["dhcp_boot_file"] = "pxelinux.0"
+default["dnsmasq"]["start"] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@ package "dnsmasq" do
 end
 
 service node[:dnsmasq][:service] do
-  action [:enable, :start]
+  action node[:dnsmasq][:start] ? [:enable, :start] : :enable
 end
 
 directory node[:dnsmasq][:conf_dir] do


### PR DESCRIPTION
With `ucarp` we don't want chef to always start `dnsmasq`
